### PR TITLE
Fixed mixed content error

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
         <meta charset="utf-8" />
         <title>Crisconru' site</title>
-        <link rel="stylesheet" href="http://crisconru.github.io/theme/css/main.css" />
-        <link href="http://crisconru.github.io/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Crisconru' site Atom Feed" />
+        <link rel="stylesheet" href="theme/css/main.css" />
+        <link href="feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Crisconru' site Atom Feed" />
 
         <!--[if IE]>
             <script src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script>


### PR DESCRIPTION
Si la web carga por HTTPS, es conveniente que las dependencias también lo hagan. La mejor forma de hacer esto es usar enlaces relativos, en lugar de absolutos (sin necesidad de poner el https://crisconru.github.io)